### PR TITLE
Distinguish float and integer values in JSON with decimal points

### DIFF
--- a/aircraftlib/aircraft.capnp.go
+++ b/aircraftlib/aircraft.capnp.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"math"
 	"net"
+	"strconv"
 )
 
 type Zdate C.Struct
@@ -925,9 +926,13 @@ func (s PlaneBase) WriteJSON(w io.Writer) error {
 		}
 		{
 			s := s.MaxSpeed()
-			buf, err = json.Marshal(s)
-			if err != nil {
-				return err
+			if float64(s) == float64(int64(s)) {
+				buf = strconv.AppendFloat(buf[:0], float64(s), 'f', 1, 64)
+			} else {
+				buf, err = json.Marshal(s)
+				if err != nil {
+					return err
+				}
 			}
 			_, err = b.Write(buf)
 			if err != nil {
@@ -2018,9 +2023,13 @@ func (s Regression) WriteJSON(w io.Writer) error {
 		}
 		{
 			s := s.B0()
-			buf, err = json.Marshal(s)
-			if err != nil {
-				return err
+			if float64(s) == float64(int64(s)) {
+				buf = strconv.AppendFloat(buf[:0], float64(s), 'f', 1, 64)
+			} else {
+				buf, err = json.Marshal(s)
+				if err != nil {
+					return err
+				}
 			}
 			_, err = b.Write(buf)
 			if err != nil {
@@ -2052,9 +2061,13 @@ func (s Regression) WriteJSON(w io.Writer) error {
 					if err != nil {
 						return err
 					}
-					buf, err = json.Marshal(s)
-					if err != nil {
-						return err
+					if float64(s) == float64(int64(s)) {
+						buf = strconv.AppendFloat(buf[:0], float64(s), 'f', 1, 64)
+					} else {
+						buf, err = json.Marshal(s)
+						if err != nil {
+							return err
+						}
 					}
 					_, err = b.Write(buf)
 					if err != nil {
@@ -2116,9 +2129,13 @@ func (s Regression) WriteJSON(w io.Writer) error {
 		}
 		{
 			s := s.Ymu()
-			buf, err = json.Marshal(s)
-			if err != nil {
-				return err
+			if float64(s) == float64(int64(s)) {
+				buf = strconv.AppendFloat(buf[:0], float64(s), 'f', 1, 64)
+			} else {
+				buf, err = json.Marshal(s)
+				if err != nil {
+					return err
+				}
 			}
 			_, err = b.Write(buf)
 			if err != nil {
@@ -2138,9 +2155,13 @@ func (s Regression) WriteJSON(w io.Writer) error {
 		}
 		{
 			s := s.Ysd()
-			buf, err = json.Marshal(s)
-			if err != nil {
-				return err
+			if float64(s) == float64(int64(s)) {
+				buf = strconv.AppendFloat(buf[:0], float64(s), 'f', 1, 64)
+			} else {
+				buf, err = json.Marshal(s)
+				if err != nil {
+					return err
+				}
 			}
 			_, err = b.Write(buf)
 			if err != nil {
@@ -2474,7 +2495,7 @@ func (c Aircraft_Which) String() string {
 	case AIRCRAFT_F16:
 		return "f16"
 	default:
-		return ""
+		panic(fmt.Errorf("invalid struct enum %d", c))
 	}
 }
 
@@ -2489,7 +2510,7 @@ func AircraftFromString(c string) Aircraft_Which {
 	case "f16":
 		return AIRCRAFT_F16
 	default:
-		return 0
+		panic(fmt.Errorf("invalid struct enum %s", c))
 	}
 }
 func NewAircraft(s *C.Segment) Aircraft      { return Aircraft(s.NewStruct(8, 1)) }
@@ -3005,7 +3026,7 @@ func (c Z_Which) String() string {
 	case Z_POWERFULAIRPORT:
 		return "powerfulAirport"
 	default:
-		return ""
+		panic(fmt.Errorf("invalid struct enum %d", c))
 	}
 }
 
@@ -3094,7 +3115,7 @@ func ZFromString(c string) Z_Which {
 	case "powerfulAirport":
 		return Z_POWERFULAIRPORT
 	default:
-		return 0
+		panic(fmt.Errorf("invalid struct enum %s", c))
 	}
 }
 func NewZ(s *C.Segment) Z      { return Z(s.NewStruct(16, 1)) }
@@ -3848,9 +3869,13 @@ func (s Z) WriteJSON(w io.Writer) error {
 			}
 			{
 				s := s.F64()
-				buf, err = json.Marshal(s)
-				if err != nil {
-					return err
+				if float64(s) == float64(int64(s)) {
+					buf = strconv.AppendFloat(buf[:0], float64(s), 'f', 1, 64)
+				} else {
+					buf, err = json.Marshal(s)
+					if err != nil {
+						return err
+					}
 				}
 				_, err = b.Write(buf)
 				if err != nil {
@@ -3872,9 +3897,13 @@ func (s Z) WriteJSON(w io.Writer) error {
 			}
 			{
 				s := s.F32()
-				buf, err = json.Marshal(s)
-				if err != nil {
-					return err
+				if float64(s) == float64(int64(s)) {
+					buf = strconv.AppendFloat(buf[:0], float64(s), 'f', 1, 64)
+				} else {
+					buf, err = json.Marshal(s)
+					if err != nil {
+						return err
+					}
 				}
 				_, err = b.Write(buf)
 				if err != nil {
@@ -4172,9 +4201,13 @@ func (s Z) WriteJSON(w io.Writer) error {
 						if err != nil {
 							return err
 						}
-						buf, err = json.Marshal(s)
-						if err != nil {
-							return err
+						if float64(s) == float64(int64(s)) {
+							buf = strconv.AppendFloat(buf[:0], float64(s), 'f', 1, 64)
+						} else {
+							buf, err = json.Marshal(s)
+							if err != nil {
+								return err
+							}
 						}
 						_, err = b.Write(buf)
 						if err != nil {
@@ -4214,9 +4247,13 @@ func (s Z) WriteJSON(w io.Writer) error {
 						if err != nil {
 							return err
 						}
-						buf, err = json.Marshal(s)
-						if err != nil {
-							return err
+						if float64(s) == float64(int64(s)) {
+							buf = strconv.AppendFloat(buf[:0], float64(s), 'f', 1, 64)
+						} else {
+							buf, err = json.Marshal(s)
+							if err != nil {
+								return err
+							}
 						}
 						_, err = b.Write(buf)
 						if err != nil {
@@ -13012,7 +13049,7 @@ func (c VoidUnion_Which) String() string {
 	case VOIDUNION_B:
 		return "b"
 	default:
-		return ""
+		panic(fmt.Errorf("invalid struct enum %d", c))
 	}
 }
 
@@ -13023,7 +13060,7 @@ func VoidUnionFromString(c string) VoidUnion_Which {
 	case "b":
 		return VOIDUNION_B
 	default:
-		return 0
+		panic(fmt.Errorf("invalid struct enum %s", c))
 	}
 }
 func NewVoidUnion(s *C.Segment) VoidUnion      { return VoidUnion(s.NewStruct(8, 0)) }

--- a/capnpc-go/capnpc-go.go
+++ b/capnpc-go/capnpc-go.go
@@ -916,10 +916,18 @@ func (t Type) json(w io.Writer) {
 	switch t.Which() {
 	case TYPE_UINT8, TYPE_UINT16, TYPE_UINT32, TYPE_UINT64,
 		TYPE_INT8, TYPE_INT16, TYPE_INT32, TYPE_INT64,
-		TYPE_FLOAT32, TYPE_FLOAT64, TYPE_BOOL, TYPE_TEXT, TYPE_DATA:
+		TYPE_BOOL, TYPE_TEXT, TYPE_DATA:
 		g_imported["encoding/json"] = true
 		fprintf(w, "buf, err = json.Marshal(s);")
 		writeErrCheck(w)
+		fprintf(w, "_, err = b.Write(buf);")
+		writeErrCheck(w)
+	case TYPE_FLOAT32, TYPE_FLOAT64:
+		g_imported["encoding/json"] = true
+		g_imported["strconv"] = true
+		fprintf(w, "if float64(s) == float64(int64(s)) { buf = strconv.AppendFloat(buf[:0], float64(s), 'f', 1, 64) } else { buf, err = json.Marshal(s);")
+		writeErrCheck(w)
+		fprintf(w, "};")
 		fprintf(w, "_, err = b.Write(buf);")
 		writeErrCheck(w)
 	case TYPE_ENUM, TYPE_STRUCT:

--- a/create_test.go
+++ b/create_test.go
@@ -86,7 +86,7 @@ func TestCreationOfZData(t *testing.T) {
 	seg, _ := zdataFilledSegment(n)
 	text := CapnpDecodeSegment(seg, "", "aircraftlib/aircraft.capnp", "Z")
 
-	expectedText := `(zdata = (data = "\x00\x01\x02\x03\x04\x05\x06\a\b\t\n\v\f\r\x0e\x0f\x10\x11\x12\x13"))`
+	expectedText := `(zdata = (data = "\000\001\002\003\004\005\006\a\b\t\n\v\f\r\016\017\020\021\022\023"))`
 
 	cv.Convey("Given a go-capnproto created Zdata DATA element with n=20", t, func() {
 		cv.Convey("When we decode it with capnp", func() {

--- a/customtype_test.go
+++ b/customtype_test.go
@@ -39,7 +39,7 @@ func TestCreationOfEndpoint(t *testing.T) {
 	seg, _ := ExampleCreateEndpoint()
 	text := CapnpDecodeSegment(seg, "", "aircraftlib/aircraft.capnp", "Endpoint")
 
-	expectedText := `(ip = "\x01\x02\x03\x04", port = 56, hostname = "test.com")`
+	expectedText := `(ip = "\001\002\003\004", port = 56, hostname = "test.com")`
 	expectedIP := net.IP([]byte{1, 2, 3, 4})
 	const expectedPort = 56
 	expectedHostname := "test.com"


### PR DESCRIPTION
This commit ensures the distinction between float and integer values in JSON representation.
Previously, float values were not being stored correctly and were being recognized as integers. The addition of decimal points to these values, even if they are whole numbers, ensures that they are stored as the correct data type in JSON.